### PR TITLE
Remove HTTP-keep-alive idle timeout

### DIFF
--- a/src/main/java/org/folio/auth/authtoken_module/impl/ModulePermissionsSource.java
+++ b/src/main/java/org/folio/auth/authtoken_module/impl/ModulePermissionsSource.java
@@ -58,7 +58,6 @@ public class ModulePermissionsSource implements PermissionsSource {
     Future<JsonArray> future = Future.future();
     HttpClientOptions options = new HttpClientOptions();
     options.setConnectTimeout(timeout);
-    options.setIdleTimeout(timeout);
     HttpClient client = vertx.createHttpClient(options);
     String okapiUrlFinal = "http://localhost:9130/";
     if(okapiUrl != null) {


### PR DESCRIPTION
The request's timeout is completely unrelated to the underlying HTTP connection's keep-alive idle timeout. By default the connection is kept open until the vertx gets closed.