### PR TITLE
Avoid storing per-request items in PermissionsSource MODAT-29

### DIFF
--- a/src/main/java/org/folio/auth/authtokenmodule/MainVerticle.java
+++ b/src/main/java/org/folio/auth/authtokenmodule/MainVerticle.java
@@ -240,8 +240,6 @@ public class MainVerticle extends AbstractVerticle {
       candidateToken = null;
     }
 
-    logger.debug("Setting tenant for permissions source to " + tenant);
-    permissionsSource.setTenant(tenant);
     /*
       In order to make our request to the permissions module
       we generate a custom token (since we have that power) that
@@ -264,7 +262,6 @@ public class MainVerticle extends AbstractVerticle {
       permissionsRequestToken = tokenCreator.createToken(permissionRequestPayload.encode());
     }
 
-    permissionsSource.setRequestToken(permissionsRequestToken);
     if (candidateToken == null) {
       logger.info("Generating dummy authtoken");
       JsonObject dummyPayload = new JsonObject();
@@ -472,7 +469,7 @@ public class MainVerticle extends AbstractVerticle {
             userId + ")");
     long startTime = System.currentTimeMillis();
     Future<PermissionData> retrievedPermissionsFuture = usePermissionsSource
-            .getUserAndExpandedPermissions(userId, extraPermissions, authToken);
+            .getUserAndExpandedPermissions(userId, tenant, permissionsRequestToken, extraPermissions, authToken);
     logger.info("Retrieving permissions for userid " + userId +
             ", and expanded permissions for " +
             extraPermissions.encode());

--- a/src/main/java/org/folio/auth/authtokenmodule/PermissionsSource.java
+++ b/src/main/java/org/folio/auth/authtokenmodule/PermissionsSource.java
@@ -2,7 +2,6 @@ package org.folio.auth.authtokenmodule;
 
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
 
 /**
  *
@@ -11,15 +10,13 @@ import io.vertx.core.json.JsonObject;
 public interface PermissionsSource {
 
   public void setOkapiUrl(String url);
-  public void setRequestToken(String token);
-  public void setAuthApiKey(String key);
-  public void setTenant(String tenant);
 
-  Future<JsonArray> getPermissionsForUser(String username);
+  Future<JsonArray> getPermissionsForUser(String username, String tenant, String requestToken);
 
-  Future<JsonArray> expandPermissions(JsonArray permissions);
+  Future<JsonArray> expandPermissions(JsonArray permissions, String tenant, String requestToken);
 
-  Future<PermissionData> getUserAndExpandedPermissions(String userid, JsonArray permissions, String key);
+  Future<PermissionData> getUserAndExpandedPermissions(String userid, String tenant, String requestToken,
+    JsonArray permissions, String key);
 
 }
 

--- a/src/main/java/org/folio/auth/authtokenmodule/impl/DummyPermissionsSource.java
+++ b/src/main/java/org/folio/auth/authtokenmodule/impl/DummyPermissionsSource.java
@@ -14,7 +14,7 @@ import org.folio.auth.authtokenmodule.PermissionData;
 public class DummyPermissionsSource implements PermissionsSource {
 
   @Override
-  public Future<JsonArray> getPermissionsForUser(String username) {
+  public Future<JsonArray> getPermissionsForUser(String username, String tenant, String requestToken) {
     Future<JsonArray> future = Future.future();
     future.complete(new JsonArray());
     return future;
@@ -26,29 +26,14 @@ public class DummyPermissionsSource implements PermissionsSource {
   }
 
   @Override
-  public void setRequestToken(String token) {
-    return;
-  }
-
-  @Override
-  public void setAuthApiKey(String key) {
-    return;
-  }
-
-  @Override
-  public void setTenant(String tenant) {
-    return;
-  }
-
-  @Override
-  public Future<JsonArray> expandPermissions(JsonArray permissions) {
+  public Future<JsonArray> expandPermissions(JsonArray permissions, String tenant, String requestToken) {
     Future<JsonArray> future = Future.future();
     future.complete(permissions);
     return future;
   }
 
   @Override
-  public Future<PermissionData> getUserAndExpandedPermissions(String userid,
+  public Future<PermissionData> getUserAndExpandedPermissions(String userid, String tenant, String requestToken,
           JsonArray permissions, String key) {
     PermissionData permissionData = new PermissionData();
     permissionData.setExpandedPermissions(permissions);

--- a/src/main/java/org/folio/auth/authtokenmodule/impl/ModulePermissionsSource.java
+++ b/src/main/java/org/folio/auth/authtokenmodule/impl/ModulePermissionsSource.java
@@ -27,7 +27,6 @@ public class ModulePermissionsSource implements PermissionsSource, Cache {
 
   private String okapiUrl = null;
   private Vertx vertx;
-  // private String requestToken;
   private final Logger logger = LoggerFactory.getLogger("mod-auth-authtoken-module");
   private final HttpClient client;
   private Map<String, CacheEntry> cacheMap;

--- a/src/main/java/org/folio/auth/authtokenmodule/impl/ModulePermissionsSource.java
+++ b/src/main/java/org/folio/auth/authtokenmodule/impl/ModulePermissionsSource.java
@@ -27,9 +27,7 @@ public class ModulePermissionsSource implements PermissionsSource, Cache {
 
   private String okapiUrl = null;
   private Vertx vertx;
-  private String requestToken;
-  private String authApiKey = "";
-  private String tenant;
+  // private String requestToken;
   private final Logger logger = LoggerFactory.getLogger("mod-auth-authtoken-module");
   private final HttpClient client;
   private Map<String, CacheEntry> cacheMap;
@@ -60,22 +58,7 @@ public class ModulePermissionsSource implements PermissionsSource, Cache {
   }
 
   @Override
-  public void setRequestToken(String token) {
-    requestToken = token;
-  }
-
-  @Override
-  public void setAuthApiKey(String key) {
-    authApiKey = key;
-  }
-
-  @Override
-  public void setTenant(String tenant) {
-    this.tenant = tenant;
-  }
-
-  @Override
-  public Future<JsonArray> getPermissionsForUser(String userid) {
+  public Future<JsonArray> getPermissionsForUser(String userid, String tenant, String requestToken) {
     Future<JsonArray> future = Future.future();
     String okapiUrlCandidate = "http://localhost:9130/";
     if (okapiUrl != null) {
@@ -151,7 +134,7 @@ public class ModulePermissionsSource implements PermissionsSource, Cache {
   }
 
   @Override
-  public Future<JsonArray> expandPermissions(JsonArray permissions) {
+  public Future<JsonArray> expandPermissions(JsonArray permissions, String tenant, String requestToken) {
     Future<JsonArray> future = Future.future();
     if (permissions.isEmpty()) {
       future.complete(new JsonArray());
@@ -253,7 +236,7 @@ public class ModulePermissionsSource implements PermissionsSource, Cache {
   }
 
   @Override
-  public Future<PermissionData> getUserAndExpandedPermissions(String userid,
+  public Future<PermissionData> getUserAndExpandedPermissions(String userid, String tenant, String requestToken,
           JsonArray permissions, String key) {
     System.out.println("getUserAndExpandedPermissions, userid=" + userid + "permissions=" +
             permissions.encode());
@@ -284,7 +267,7 @@ public class ModulePermissionsSource implements PermissionsSource, Cache {
       userPermsFuture = Future.succeededFuture(currentCache[0].getPermissions());
     } else {
       logger.info("Retrieving permissions for user");
-      userPermsFuture = getPermissionsForUser(userid);
+      userPermsFuture = getPermissionsForUser(userid, tenant, requestToken);
     }
     Future<JsonArray> expandedPermsFuture;
     if(cacheEntries && currentCache[0].getExpandedPermissions() != null) {
@@ -292,7 +275,7 @@ public class ModulePermissionsSource implements PermissionsSource, Cache {
       expandedPermsFuture = Future.succeededFuture(currentCache[0].getExpandedPermissions());
     } else {
       logger.info("Expanding permissions");
-      expandedPermsFuture = expandPermissions(permissions);
+      expandedPermsFuture = expandPermissions(permissions, tenant, requestToken);
     }
     CompositeFuture compositeFuture = CompositeFuture.all(userPermsFuture, expandedPermsFuture);
     compositeFuture.setHandler(compositeRes -> {


### PR DESCRIPTION
Fixes concurrency issue with tenant. Remove setAuthApiKey method from
interface (not in use).