### PR TITLE
Make extra permissions work, fix cache key calculation MODAT-47

### DIFF
--- a/src/main/java/org/folio/auth/authtokenmodule/impl/ModulePermissionsSource.java
+++ b/src/main/java/org/folio/auth/authtokenmodule/impl/ModulePermissionsSource.java
@@ -32,14 +32,14 @@ public class ModulePermissionsSource implements PermissionsSource, Cache {
   private final Logger logger = LoggerFactory.getLogger("mod-auth-authtoken-module");
   private final HttpClient client;
   private LimitedSizeMap<String, CacheEntry> cacheMap;
-  private boolean cacheEntries;
+  private boolean cacheEnabled;
   private final String keyPrefix;
   private final int MAX_CACHE_SIZE = 250;
 
 
   public ModulePermissionsSource(Vertx vertx, int timeout, boolean cache) {
     //permissionsModuleUrl = url;
-    cacheEntries = cache;
+    cacheEnabled = cache;
     this.vertx = vertx;
     HttpClientOptions options = new HttpClientOptions();
     options.setConnectTimeout(timeout * 1000);
@@ -249,7 +249,7 @@ public class ModulePermissionsSource implements PermissionsSource, Cache {
     boolean[] gotNewExpandedPerms = new boolean[1];
     gotNewPerms[0] = false;
     gotNewExpandedPerms[0] = false;
-    if(cacheEntries) {
+    if(cacheEnabled) {
       if (key == null) {
         key = keyPrefix;
       }
@@ -278,7 +278,7 @@ public class ModulePermissionsSource implements PermissionsSource, Cache {
     final String finalKey = key;
     Future<PermissionData> future = Future.future();
     Future<JsonArray> userPermsFuture;
-    if(cacheEntries && currentCache[0].getPermissions() != null) {
+    if(cacheEnabled && currentCache[0].getPermissions() != null) {
       logger.debug("Using entry from cache for user permissions");
       userPermsFuture = Future.succeededFuture(currentCache[0].getPermissions());
     } else {
@@ -287,7 +287,7 @@ public class ModulePermissionsSource implements PermissionsSource, Cache {
       gotNewPerms[0] = true;
     }
     Future<JsonArray> expandedPermsFuture;
-    if(cacheEntries && currentCache[0].getExpandedPermissions() != null) {
+    if(cacheEnabled && currentCache[0].getExpandedPermissions() != null) {
       logger.debug("Using entry from cache for expanded permissions");
       expandedPermsFuture = Future.succeededFuture(currentCache[0].getExpandedPermissions());
     } else {
@@ -304,7 +304,7 @@ public class ModulePermissionsSource implements PermissionsSource, Cache {
         PermissionData permissionData = new PermissionData();
         permissionData.setUserPermissions(userPermsFuture.result());
         permissionData.setExpandedPermissions(expandedPermsFuture.result());
-        if(cacheEntries) {
+        if(cacheEnabled) {
           JsonArray copiedUserPerms = new JsonArray();
           JsonArray copiedExpandedPerms = new JsonArray();
           for(Object p : userPermsFuture.result()) {

--- a/src/main/java/org/folio/auth/authtokenmodule/impl/ModulePermissionsSource.java
+++ b/src/main/java/org/folio/auth/authtokenmodule/impl/ModulePermissionsSource.java
@@ -250,8 +250,8 @@ public class ModulePermissionsSource implements PermissionsSource, Cache {
     gotNewPerms[0] = false;
     gotNewExpandedPerms[0] = false;
     if(cacheEntries) {
-      if(key == null && userid == null && permissions != null) {
-        key = keyPrefix + permissions.encode();
+      if (key == null) {
+        key = keyPrefix;
       }
       if (permissions != null && !key.endsWith(permissions.encode())) {
         key += permissions.encode();

--- a/src/main/java/org/folio/auth/authtokenmodule/impl/ModulePermissionsSource.java
+++ b/src/main/java/org/folio/auth/authtokenmodule/impl/ModulePermissionsSource.java
@@ -257,7 +257,7 @@ public class ModulePermissionsSource implements PermissionsSource, Cache {
     CacheEntry[] currentCache = new CacheEntry[1];
     boolean[] gotNewPerms = new boolean[1];
     boolean[] gotNewExpandedPerms = new boolean[1];
-    final String finalKey = cacheEntries ? cacheKey(key, permissions) : null;
+    final String finalKey = cacheEnabled ? cacheKey(key, permissions) : null;
     gotNewPerms[0] = false;
     gotNewExpandedPerms[0] = false;
     if (finalKey != null) {

--- a/src/main/java/org/folio/auth/authtokenmodule/impl/ModulePermissionsSource.java
+++ b/src/main/java/org/folio/auth/authtokenmodule/impl/ModulePermissionsSource.java
@@ -253,6 +253,9 @@ public class ModulePermissionsSource implements PermissionsSource, Cache {
       if(key == null && userid == null && permissions != null) {
         key = keyPrefix + permissions.encode();
       }
+      if (permissions != null && !key.endsWith(permissions.encode())) {
+        key += permissions.encode();
+      }
       logger.debug("Attempting to find cache with key of '{}'", key);
       currentCache[0] = cacheMap.getOrDefault(key, null);
       boolean found = true;
@@ -313,7 +316,7 @@ public class ModulePermissionsSource implements PermissionsSource, Cache {
           }
           if( (gotNewPerms[0] && copiedUserPerms.size() > 0) ||
               (gotNewExpandedPerms[0] && copiedExpandedPerms.size() > 0)) {
-            // currentCache[0].setExpandedPermissions(copiedExpandedPerms);
+            currentCache[0].setExpandedPermissions(copiedExpandedPerms);
             logger.debug("Setting populated cache with key of {}", finalKey);
             currentCache[0].resetTime();
             cacheMap.put(finalKey, currentCache[0]);

--- a/src/main/java/org/folio/auth/authtokenmodule/impl/ModulePermissionsSource.java
+++ b/src/main/java/org/folio/auth/authtokenmodule/impl/ModulePermissionsSource.java
@@ -159,7 +159,7 @@ public class ModulePermissionsSource implements PermissionsSource, Cache {
     }
     try {
       String requestUrl = okapiUrlFinal + "perms/permissions?"
-              + URLEncoder.encode("expandSubs=true&query=" + query, "UTF-8");
+              + "expandSubs=true&query=" + URLEncoder.encode(query, "UTF-8");
       logger.debug("Requesting expanded permissions from URL at " + requestUrl);
       HttpClientRequest req = client.getAbs(requestUrl, res -> {
         res.bodyHandler(body -> {
@@ -313,10 +313,10 @@ public class ModulePermissionsSource implements PermissionsSource, Cache {
           }
           if( (gotNewPerms[0] && copiedUserPerms.size() > 0) ||
               (gotNewExpandedPerms[0] && copiedExpandedPerms.size() > 0)) {
-            currentCache[0].setExpandedPermissions(copiedExpandedPerms);
-                logger.debug("Setting populated cache with key of {}", finalKey);
+            // currentCache[0].setExpandedPermissions(copiedExpandedPerms);
+            logger.debug("Setting populated cache with key of {}", finalKey);
             currentCache[0].resetTime();
-          cacheMap.put(finalKey, currentCache[0]);
+            cacheMap.put(finalKey, currentCache[0]);
           }
         }
         future.complete(permissionData);


### PR DESCRIPTION
The URLEncoder.encode usage is OK and results in what appears
to be correct expanded permissions for extra-permission. The
extra permissions caching, however, is disabled by this and should
be fixed.