### PR TITLE
Attempt at fixing FOLIO-2366

### DIFF
--- a/src/main/java/org/folio/auth/authtokenmodule/MainVerticle.java
+++ b/src/main/java/org/folio/auth/authtokenmodule/MainVerticle.java
@@ -629,10 +629,12 @@ public class MainVerticle extends AbstractVerticle {
     }
 
     PermissionsSource usePermissionsSource;
+    boolean dummyPermissionSource = false;
     if((tokenClaims.getBoolean("dummy") != null && tokenClaims.getBoolean("dummy"))
             || username.startsWith(UNDEFINED_USER_NAME)) {
       logger.debug("Using dummy permissions source");
       usePermissionsSource = new DummyPermissionsSource();
+      dummyPermissionSource = true;
     } else {
       usePermissionsSource = permissionsSource;
     }
@@ -648,7 +650,7 @@ public class MainVerticle extends AbstractVerticle {
 
     // Need to check if the user is still active
     Future<PermissionData> retrievedPermissionsFuture;
-    if (finalUserId != null && !finalUserId.trim().isEmpty()) {
+    if (!dummyPermissionSource && finalUserId != null && !finalUserId.trim().isEmpty()) {
       Future<Boolean> activeUser = userService.isActiveUser(finalUserId, tenant, okapiUrl, userRequestToken, requestId);
       retrievedPermissionsFuture = activeUser.compose(b -> {
         if (b != null && b.booleanValue()) {

--- a/src/test/java/org/folio/auth/authtokenmodule/AuthTokenTest.java
+++ b/src/test/java/org/folio/auth/authtokenmodule/AuthTokenTest.java
@@ -433,7 +433,7 @@ public class AuthTokenTest {
       .header("X-Okapi-Permissions-Desired", "extra.*bar")
       .get("/bar")
       .then()
-      .statusCode(400).body(containsString("Connection refused"));
+      .statusCode(401).body(containsString("Unexpected request exception for user id "));
 
     logger.info("Test /permss/users with bad status");
     PermsMock.handlePermsUsersStatusCode = 400;


### PR DESCRIPTION
The theroy is that the user lookup does not obey dummy permissions
which do NOT have user info associated with them, eg permissions
lookup is disabled for that and should be too for user lookup.
This should not be merged. Can be me much prettier.