### PR TITLE
MODAT-62 - Issue with log4j configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,12 +179,21 @@
                     <Main-Verticle>org.folio.auth.authtokenmodule.MainVerticle</Main-Verticle>
                   </manifestEntries>
                 </transformer>
+                <!-- See https://issues.apache.org/jira/browse/LOG4J2-673 -->
+                <transformer implementation="com.github.edwgiz.maven_shade_plugin.log4j2_cache_transformer.PluginsCacheFileTransformer"/>
               </transformers>
               <artifactSet />
               <outputFile>${project.build.directory}/${project.artifactId}-fat.jar</outputFile>
             </configuration>
           </execution>
         </executions>
+        <dependencies>
+          <dependency>
+            <groupId>com.github.edwgiz</groupId>
+            <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
+            <version>2.13.0</version>
+          </dependency>
+        </dependencies>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Purpose
Since moving to log4j2 (https://github.com/folio-org/mod-authtoken/pull/70) we've run into an issue with `log4j2Plugins.dat` colliding with those from 3rd party dependencies while shading.  

See: https://issues.apache.org/jira/browse/LOG4J2-673.
See: https://issues.folio.org/browse/MODAT-62

## Approach
Use a shade plugin transformer which merges the various `log4jPlugins.dat` files.

See https://github.com/edwgiz/maven-shaded-log4j-transformer


 