### PR TITLE
MODAT-72 Expand module permission set

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -24,7 +24,7 @@
   "requires" : [
     {
       "id" : "permissions",
-      "version" : "5.2"
+      "version" : "5.3"
     },
     {
       "id" : "users",

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,12 @@
       <version>2.8.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>3.3.3</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/src/main/java/org/folio/auth/authtokenmodule/AuthRoutingEntry.java
+++ b/src/main/java/org/folio/auth/authtokenmodule/AuthRoutingEntry.java
@@ -54,6 +54,7 @@ public class AuthRoutingEntry {
     if (ctx.getBodyAsString() == null || ctx.getBodyAsString().isEmpty()) {
       logger.debug(String.format("No body found in request for %s, treating as filter", endpoint));
       //check for permissions
+      extraPermissions = PermService.expandSystemPermissionsUsingCache(extraPermissions);
       boolean allFound = true;
       for (String perm : requiredPermissions) {
         if (!extraPermissions.contains(perm)) {

--- a/src/main/java/org/folio/auth/authtokenmodule/MainVerticle.java
+++ b/src/main/java/org/folio/auth/authtokenmodule/MainVerticle.java
@@ -669,12 +669,11 @@ public class MainVerticle extends AbstractVerticle {
         }
       });
     } else if (dummyPermissionSource) {
-      Future<JsonArray> expandSystemPermissions = permService.expandSystemPermissions(
-          extraPermissions, tenant, okapiUrl, permissionsRequestToken, requestId);
-      retrievedPermissionsFuture = expandSystemPermissions.compose(expandedPermissions -> {
-        return usePermissionsSource.getUserAndExpandedPermissions(finalUserId, tenant, okapiUrl,
-            permissionsRequestToken, requestId, expandedPermissions);
-      });
+      Future<JsonArray> expandSystemPermissions = permService.expandSystemPermissions(extraPermissions, tenant,
+          okapiUrl, permissionsRequestToken, requestId);
+      retrievedPermissionsFuture = expandSystemPermissions
+          .compose(expandedPermissions -> usePermissionsSource.getUserAndExpandedPermissions(finalUserId, tenant,
+              okapiUrl, permissionsRequestToken, requestId, expandedPermissions));
     } else {
       retrievedPermissionsFuture = usePermissionsSource.getUserAndExpandedPermissions(finalUserId, tenant, okapiUrl,
           permissionsRequestToken, requestId, extraPermissions);

--- a/src/main/java/org/folio/auth/authtokenmodule/PermService.java
+++ b/src/main/java/org/folio/auth/authtokenmodule/PermService.java
@@ -52,18 +52,19 @@ public class PermService {
    * @return original permissions plus sub permissions
    */
   public static JsonArray expandSystemPermissionsUsingCache(JsonArray permissions) {
-    JsonArray perms = new JsonArray();
+    JsonArray expandedPerms = new JsonArray();
     for (int i = 0, n = permissions.size(); i < n; i++) {
       String perm = permissions.getString(i);
       PermEntry entry = cache.get(perm);
       if (entry != null) {
-        perms.addAll(entry.getPerms());
+        expandedPerms.addAll(entry.getPerms());
         entry.updateTimestamp();
       } else {
-        perms.add(perm);
+        expandedPerms.add(perm);
       }
     }
-    return perms;
+    logger.debug("Expand using static cache from " + permissions + " to " + expandedPerms);
+    return expandedPerms;
   }
 
   /**
@@ -108,6 +109,7 @@ public class PermService {
           expandedPerms.addAll(perms);
         });
         future.complete(expandedPerms);
+        logger.debug("Expand from " + permissions + " to " + expandedPerms);
       } else {
         future.fail(ar.cause());
         logger.error("Failed to expand permissions", ar.cause());

--- a/src/main/java/org/folio/auth/authtokenmodule/PermService.java
+++ b/src/main/java/org/folio/auth/authtokenmodule/PermService.java
@@ -1,0 +1,134 @@
+package org.folio.auth.authtokenmodule;
+
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.folio.auth.authtokenmodule.impl.ModulePermissionsSource;
+
+/**
+ * Help to expand system generated module permission set to the actual permissions.
+ */
+public class PermService {
+
+  private static final Logger logger = LoggerFactory.getLogger(PermService.class);
+  // map from system generated module permission set name to the actual permissions
+  private static ConcurrentMap<String, PermEntry> cache = new ConcurrentHashMap<>();
+  private ModulePermissionsSource modulePermissionsSource;
+  private long cachePeriod;
+
+  public PermService(Vertx vertx, ModulePermissionsSource modulePermissionsSource,
+      int cacheInSeconds, int purgeCacheInSeconds) {
+    this.modulePermissionsSource = modulePermissionsSource;
+
+    // purge less used cache entry periodically
+    cachePeriod = cacheInSeconds * 1000L;
+    vertx.setPeriodic(purgeCacheInSeconds * 1000L, id -> {
+      logger.info("Purge system permission set cache");
+      Set<String> keys = new HashSet<>(cache.keySet());
+      for (String key : keys) {
+        if ((System.currentTimeMillis() - cache.get(key).getTimestamp()) > cachePeriod) {
+          cache.remove(key);
+          logger.info("Removed cache of system permission: " + key);
+        }
+      }
+    });
+  }
+
+  /**
+   * Expand system permissions using cache. If not cached, return as is.
+   *
+   * @param permissions
+   * @return original permissions plus sub permissions
+   */
+  public static JsonArray expandSystemPermissionsUsingCache(JsonArray permissions) {
+    JsonArray perms = new JsonArray().addAll(permissions);
+    for (int i = 0, n = permissions.size(); i < n; i++) {
+      PermEntry entry = cache.get(permissions.getString(i));
+      if (entry != null) {
+        entry.updateTimestamp();
+        perms.addAll(entry.getPerms());
+      }
+    }
+    return perms;
+  }
+
+  /**
+   * Expand system permissions.
+   *
+   * @param permissions
+   * @param tenant
+   * @param okapiUrl
+   * @param requestToken
+   * @param requestId
+   * @return
+   */
+  public Future<JsonArray> expandSystemPermissions(JsonArray permissions, String tenant,
+      String okapiUrl, String requestToken, String requestId) {
+    Future<JsonArray> future = Future.future();
+    JsonArray expandedPerms = new JsonArray().addAll(permissions);
+    @SuppressWarnings("rawtypes")
+    List<Future> futures = new ArrayList<>();
+    for (int i = 0, n = permissions.size(); i < n; i++) {
+      String perm = permissions.getString(i);
+      if (!perm.startsWith("SYS#")) {
+        continue;
+      }
+      PermEntry entry = cache.get(perm);
+      if (entry != null) {
+        entry.updateTimestamp();
+        expandedPerms.addAll(entry.getPerms());
+        continue;
+      }
+      futures.add(modulePermissionsSource.expandPermissionsCached(new JsonArray().add(perm), tenant,
+          okapiUrl, requestToken, requestId));
+    }
+    CompositeFuture.join(futures).setHandler(ar -> {
+      if (ar.succeeded()) {
+        futures.forEach(f -> {
+          JsonArray perms = (JsonArray) f.result();
+          String perm = perms.getString(0);
+          perms.remove(0);
+          cache.put(perm, new PermEntry(perms));
+          expandedPerms.addAll(perms);
+        });
+        future.complete(expandedPerms);
+      } else {
+        future.fail(ar.cause());
+        logger.error("Failed to expand permissions", ar.cause());
+      }
+    });
+    return future;
+  }
+
+  private static class PermEntry {
+    private long timestamp = System.currentTimeMillis();
+
+    private JsonArray perms = new JsonArray();
+
+    public PermEntry(JsonArray perms) {
+      this.perms = perms;
+    }
+
+    public long getTimestamp() {
+      return timestamp;
+    }
+
+    public JsonArray getPerms() {
+      return perms;
+    }
+
+    public void updateTimestamp() {
+      timestamp = System.currentTimeMillis();
+    }
+  }
+
+}

--- a/src/main/java/org/folio/auth/authtokenmodule/PermService.java
+++ b/src/main/java/org/folio/auth/authtokenmodule/PermService.java
@@ -15,18 +15,20 @@ import java.util.concurrent.ConcurrentMap;
 import org.folio.auth.authtokenmodule.impl.ModulePermissionsSource;
 
 /**
- * Help to expand system generated module permission set to the actual permissions.
+ * Help to expand system generated module permission set to the actual
+ * permissions.
  */
 public class PermService {
 
   private static final Logger logger = LoggerFactory.getLogger(PermService.class);
-  // map from system generated module permission set name to the actual permissions
+  // map from system generated module permission set name to the actual
+  // permissions
   private static ConcurrentMap<String, PermEntry> cache = new ConcurrentHashMap<>();
   private ModulePermissionsSource modulePermissionsSource;
   private long cachePeriod;
 
-  public PermService(Vertx vertx, ModulePermissionsSource modulePermissionsSource,
-      int cacheInSeconds, int purgeCacheInSeconds) {
+  public PermService(Vertx vertx, ModulePermissionsSource modulePermissionsSource, int cacheInSeconds,
+      int purgeCacheInSeconds) {
     this.modulePermissionsSource = modulePermissionsSource;
 
     // purge less used cache entry periodically
@@ -71,8 +73,9 @@ public class PermService {
    * @param requestId
    * @return
    */
-  public Future<JsonArray> expandSystemPermissions(JsonArray permissions, String tenant,
-      String okapiUrl, String requestToken, String requestId) {
+  @SuppressWarnings("java:S3740")
+  public Future<JsonArray> expandSystemPermissions(JsonArray permissions, String tenant, String okapiUrl,
+      String requestToken, String requestId) {
     Future<JsonArray> future = Future.future();
     JsonArray expandedPerms = new JsonArray().addAll(permissions);
     @SuppressWarnings("rawtypes")
@@ -86,10 +89,10 @@ public class PermService {
       if (entry != null) {
         entry.updateTimestamp();
         expandedPerms.addAll(entry.getPerms());
-        continue;
+      } else {
+        futures.add(modulePermissionsSource.expandPermissionsCached(new JsonArray().add(perm), tenant, okapiUrl,
+            requestToken, requestId));
       }
-      futures.add(modulePermissionsSource.expandPermissionsCached(new JsonArray().add(perm), tenant,
-          okapiUrl, requestToken, requestId));
     }
     CompositeFuture.join(futures).setHandler(ar -> {
       if (ar.succeeded()) {

--- a/src/main/java/org/folio/auth/authtokenmodule/impl/ModulePermissionsSource.java
+++ b/src/main/java/org/folio/auth/authtokenmodule/impl/ModulePermissionsSource.java
@@ -187,7 +187,7 @@ public class ModulePermissionsSource implements PermissionsSource {
     query = query + joiner.toString() + ")";
     try {
       String requestUrl = okapiUrl + "/perms/permissions?"
-        + "expandSubs=true&query=" + URLEncoder.encode(query, "UTF-8");
+        + "expanded=true&query=" + URLEncoder.encode(query, "UTF-8");
       logger.debug("Requesting expanded permissions from URL at " + requestUrl);
       HttpClientRequest req = client.getAbs(requestUrl, res -> {
         res.bodyHandler(body -> handleExpandPermissions(res, body, future, permissions));

--- a/src/main/java/org/folio/auth/authtokenmodule/impl/ModulePermissionsSource.java
+++ b/src/main/java/org/folio/auth/authtokenmodule/impl/ModulePermissionsSource.java
@@ -151,7 +151,7 @@ public class ModulePermissionsSource implements PermissionsSource {
     req.end();
   }
 
-  private Future<JsonArray> expandPermissionsCached(JsonArray permissions,
+  public Future<JsonArray> expandPermissionsCached(JsonArray permissions,
     String tenant, String okapiUrl, String requestToken, String requestId) {
 
     final String key = tenant + "_" + permissions.encodePrettily();
@@ -182,7 +182,7 @@ public class ModulePermissionsSource implements PermissionsSource {
     StringJoiner joiner = new StringJoiner(" or ");
     for (Object ob : permissions) {
       String permissionName = (String) ob;
-      joiner.add("permissionName==" + permissionName + "");
+      joiner.add("permissionName==\"" + permissionName + "\"");
     }
     query = query + joiner.toString() + ")";
     try {

--- a/src/test/java/org/folio/auth/authtokenmodule/PermServiceTest.java
+++ b/src/test/java/org/folio/auth/authtokenmodule/PermServiceTest.java
@@ -30,8 +30,7 @@ public class PermServiceTest {
     vertx = Vertx.vertx();
     mps = mock(ModulePermissionsSource.class);
     JsonArray perms = new JsonArray().add(SYS_PERM).add(SUB_PERM_1).add(SUB_PERM_2);
-    when(mps.expandPermissionsCached(any(), any(), any(), any(), any()))
-        .thenReturn(Future.succeededFuture(perms));
+    when(mps.expandPermissionsCached(any(), any(), any(), any(), any())).thenReturn(Future.succeededFuture(perms));
     permService = new PermService(vertx, mps, 2, 2);
   }
 
@@ -41,7 +40,7 @@ public class PermServiceTest {
     JsonArray perms = new JsonArray().add(SYS_PERM);
     JsonArray rs = PermService.expandSystemPermissionsUsingCache(perms);
     // no static cache
-    assertTrue(rs.size() == 1);
+    assertEquals(1, rs.size());
     assertTrue(rs.contains(SYS_PERM));
     // no cache
     rs = callExpandPerms(perms);
@@ -74,8 +73,7 @@ public class PermServiceTest {
     when(badMps.expandPermissionsCached(any(), any(), any(), any(), any()))
         .thenReturn(Future.failedFuture("test failure"));
     PermService ps = new PermService(vertx, badMps, 10, 10);
-    Future<JsonArray> rs =
-        ps.expandSystemPermissions(new JsonArray().add("SYS#2"), "a", "a", "a", "a");
+    Future<JsonArray> rs = ps.expandSystemPermissions(new JsonArray().add("SYS#2"), "a", "a", "a", "a");
     assertTrue(rs.failed());
   }
 
@@ -84,8 +82,7 @@ public class PermServiceTest {
   }
 
   private void verifyExpandPerms(JsonArray rs) {
-    assertEquals(3, rs.size());
-    assertTrue(rs.contains(SYS_PERM));
+    assertEquals(2, rs.size());
     assertTrue(rs.contains(SUB_PERM_1));
     assertTrue(rs.contains(SUB_PERM_2));
   }

--- a/src/test/java/org/folio/auth/authtokenmodule/PermServiceTest.java
+++ b/src/test/java/org/folio/auth/authtokenmodule/PermServiceTest.java
@@ -1,0 +1,92 @@
+package org.folio.auth.authtokenmodule;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import org.junit.runner.RunWith;
+import org.folio.auth.authtokenmodule.impl.ModulePermissionsSource;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+@RunWith(VertxUnitRunner.class)
+public class PermServiceTest {
+
+  private static final String SYS_PERM = "SYS#1";
+  private static final String SUB_PERM_1 = "user.read";
+  private static final String SUB_PERM_2 = "user.write";
+
+  private static Vertx vertx;
+  private static ModulePermissionsSource mps;
+  private static PermService permService;
+
+  @BeforeClass
+  public static void setup() {
+    vertx = Vertx.vertx();
+    mps = mock(ModulePermissionsSource.class);
+    JsonArray perms = new JsonArray().add(SYS_PERM).add(SUB_PERM_1).add(SUB_PERM_2);
+    when(mps.expandPermissionsCached(any(), any(), any(), any(), any()))
+        .thenReturn(Future.succeededFuture(perms));
+    permService = new PermService(vertx, mps, 2, 2);
+  }
+
+  @Test
+  public void testExpandPermissions(TestContext context) {
+    Async async = context.async();
+    JsonArray perms = new JsonArray().add(SYS_PERM);
+    JsonArray rs = PermService.expandSystemPermissionsUsingCache(perms);
+    // no static cache
+    assertTrue(rs.size() == 1);
+    assertTrue(rs.contains(SYS_PERM));
+    // no cache
+    rs = callExpandPerms(perms);
+    verifyExpandPerms(rs);
+    // use cache
+    rs = callExpandPerms(perms);
+    verifyExpandPerms(rs);
+    // has static cache
+    rs = PermService.expandSystemPermissionsUsingCache(perms);
+    verifyExpandPerms(rs);
+    // test cache purge
+    vertx.setTimer(4000, id -> {
+      JsonArray ja = PermService.expandSystemPermissionsUsingCache(perms);
+      context.assertEquals(1, ja.size());
+      async.complete();
+    });
+  }
+
+  @Test
+  public void testExpandNonSystemPerm() {
+    String perm = "test.read";
+    JsonArray rs = callExpandPerms(new JsonArray().add(perm));
+    assertEquals(1, rs.size());
+    assertTrue(rs.contains(perm));
+  }
+
+  @Test
+  public void testFailedFuture() throws InterruptedException {
+    ModulePermissionsSource badMps = mock(ModulePermissionsSource.class);
+    when(badMps.expandPermissionsCached(any(), any(), any(), any(), any()))
+        .thenReturn(Future.failedFuture("test failure"));
+    PermService ps = new PermService(vertx, badMps, 10, 10);
+    Future<JsonArray> rs =
+        ps.expandSystemPermissions(new JsonArray().add("SYS#2"), "a", "a", "a", "a");
+    assertTrue(rs.failed());
+  }
+
+  private JsonArray callExpandPerms(JsonArray perms) {
+    return permService.expandSystemPermissions(perms, "a", "a", "a", "a").result();
+  }
+
+  private void verifyExpandPerms(JsonArray rs) {
+    assertEquals(3, rs.size());
+    assertTrue(rs.contains(SYS_PERM));
+    assertTrue(rs.contains(SUB_PERM_1));
+    assertTrue(rs.contains(SUB_PERM_2));
+  }
+}


### PR DESCRIPTION
In OKAPI-837, we automatically convert module permissions to a permission set. Unfortunately mod-authtoken does not expand permission set to permissions for certain scenarios where no real user id is involved. For example during initial login or Okapi timer based system calls. This PR is to address this issue.