### PR TITLE
Provide permissionsRequired MODAT-77

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -8,15 +8,18 @@
       "handlers" : [
         {
           "methods" : [ "POST" ],
-          "pathPattern" : "/token"
+          "pathPattern" : "/token",
+          "permissionsRequired": []
         },
         {
           "methods" : [ "POST" ],
-          "pathPattern" : "/refreshtoken"
+          "pathPattern" : "/refreshtoken",
+          "permissionsRequired": []
         },
         {
           "methods" : [ "POST" ],
-          "pathPattern" : "/refresh"
+          "pathPattern" : "/refresh",
+          "permissionsRequired": []
         }
       ]
     }


### PR DESCRIPTION
System is not building because okapi 3.0.0 is out and permissionsRequired is required.