### PR TITLE
MODAT-88: migrate to JDK11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,7 @@ buildMvn {
   publishAPI = 'no'
   mvnDeploy = 'yes'
   doKubeDeploy = true
+  buildNode = 'jenkins-agent-java11'
 
   doDocker = {
     buildJavaDocker {

--- a/pom.xml
+++ b/pom.xml
@@ -84,9 +84,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.jayway.restassured</groupId>
+      <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
-      <version>2.8.0</version>
+      <version>4.3.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -114,8 +114,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.1</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <release>11</release>
+          <encoding>UTF-8</encoding>
         </configuration>
       </plugin>
       <plugin>

--- a/src/test/java/org/folio/auth/authtokenmodule/AuthTokenTest.java
+++ b/src/test/java/org/folio/auth/authtokenmodule/AuthTokenTest.java
@@ -1,7 +1,7 @@
 package org.folio.auth.authtokenmodule;
 
-import com.jayway.restassured.RestAssured;
-import com.jayway.restassured.response.Response;
+import io.restassured.RestAssured;
+import io.restassured.response.Response;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.util.Base64;
 import io.vertx.core.DeploymentOptions;
@@ -22,7 +22,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import static com.jayway.restassured.RestAssured.*;
+import static io.restassured.RestAssured.*;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertTrue;
 import static org.folio.auth.authtokenmodule.MainVerticle.OKAPI_TOKEN_HEADER;
@@ -935,7 +935,7 @@ public class AuthTokenTest {
       .body(new JsonObject().put("passPhrase", secret).put("payload", "gyf").encode())
       .post("/encrypted-token/create")
       .then()
-      .statusCode(400).body(containsString("java.lang.String cannot be cast to io.vertx.core.json.JsonObject"));
+      .statusCode(400).body(containsString("java.lang.String cannot be cast to class io.vertx.core.json.JsonObject"));
 
     String encryptedTokenResponse = r.getBody().asString();
     JsonObject encryptedTokenJson = new JsonObject(encryptedTokenResponse);


### PR DESCRIPTION
Migrate to JDK11

* Upgrade rest assured due to https://github.com/rest-assured/rest-assured/issues/1175
* Specify the jdk11 build node in Jenkinsfile
* Update maven compiler plugin configuration

See https://issues.folio.org/browse/MODAT-88