### PR TITLE
MODAT-88 Dockerfile use new base image jdk11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM folioci/alpine-jre-openjdk8:latest
+FROM folioci/alpine-jre-openjdk11:latest
 
 ENV VERTICLE_FILE mod-authtoken-fat.jar
 


### PR DESCRIPTION
See https://dev.folio.org/faqs/how-to-specify-backend-java-ci/