### PR TITLE
Partly revert MODAT-107

### DIFF
--- a/src/main/java/org/folio/auth/authtokenmodule/MainVerticle.java
+++ b/src/main/java/org/folio/auth/authtokenmodule/MainVerticle.java
@@ -692,6 +692,7 @@ public class MainVerticle extends AbstractVerticle {
           endText(ctx, 401, "Invalid token: " + res.cause().getLocalizedMessage());
           return;
         }
+        ctx.response().putHeader(XOkapiHeaders.MODULE_TOKENS, moduleTokens.encode())
         endText(ctx, 400, "Unable to retrieve permissions for user with id'"
           + finalUserId + "': " + res.cause().getLocalizedMessage());
         return;
@@ -709,6 +710,7 @@ public class MainVerticle extends AbstractVerticle {
           logger.error(permissions.encode() + "{}(user permissions) nor {}"
             + "(module permissions) do not contain {}",
           permissions.encode(), extraPermissions.encode(), o);
+          ctx.response().putHeader(XOkapiHeaders.MODULE_TOKENS, moduleTokens.encode())
           endText(ctx, 403, "Access requires permission: " + o);
           return;
         }
@@ -739,6 +741,7 @@ public class MainVerticle extends AbstractVerticle {
       } catch(Exception e) {
         String message = String.format("Error creating access token: %s", e.getMessage());
         logger.error(message);
+        ctx.response().putHeader(XOkapiHeaders.MODULE_TOKENS, moduleTokens.encode())
         endText(ctx, 500, "Error creating access token");
         return;
       }

--- a/src/main/java/org/folio/auth/authtokenmodule/MainVerticle.java
+++ b/src/main/java/org/folio/auth/authtokenmodule/MainVerticle.java
@@ -692,6 +692,8 @@ public class MainVerticle extends AbstractVerticle {
           endText(ctx, 401, "Invalid token: " + res.cause().getLocalizedMessage());
           return;
         }
+        // mod-authtoken should return the module tokens header even in case of errors.
+        // If not, pre+post filters will NOT get modulePermissions from Okapi
         ctx.response().putHeader(XOkapiHeaders.MODULE_TOKENS, moduleTokens.encode());
         endText(ctx, 400, "Unable to retrieve permissions for user with id'"
           + finalUserId + "': " + res.cause().getLocalizedMessage());
@@ -710,6 +712,8 @@ public class MainVerticle extends AbstractVerticle {
           logger.error(permissions.encode() + "{}(user permissions) nor {}"
             + "(module permissions) do not contain {}",
           permissions.encode(), extraPermissions.encode(), o);
+          // mod-authtoken should return the module tokens header even in case of errors.
+          // If not, pre+post filters will NOT get modulePermissions from Okapi
           ctx.response().putHeader(XOkapiHeaders.MODULE_TOKENS, moduleTokens.encode());
           endText(ctx, 403, "Access requires permission: " + o);
           return;
@@ -741,6 +745,8 @@ public class MainVerticle extends AbstractVerticle {
       } catch(Exception e) {
         String message = String.format("Error creating access token: %s", e.getMessage());
         logger.error(message);
+        // mod-authtoken should return the module tokens header even in case of errors.
+        // If not, pre+post filters will NOT get modulePermissions from Okapi.
         ctx.response().putHeader(XOkapiHeaders.MODULE_TOKENS, moduleTokens.encode());
         endText(ctx, 500, "Error creating access token");
         return;

--- a/src/main/java/org/folio/auth/authtokenmodule/MainVerticle.java
+++ b/src/main/java/org/folio/auth/authtokenmodule/MainVerticle.java
@@ -692,7 +692,7 @@ public class MainVerticle extends AbstractVerticle {
           endText(ctx, 401, "Invalid token: " + res.cause().getLocalizedMessage());
           return;
         }
-        ctx.response().putHeader(XOkapiHeaders.MODULE_TOKENS, moduleTokens.encode())
+        ctx.response().putHeader(XOkapiHeaders.MODULE_TOKENS, moduleTokens.encode());
         endText(ctx, 400, "Unable to retrieve permissions for user with id'"
           + finalUserId + "': " + res.cause().getLocalizedMessage());
         return;
@@ -710,7 +710,7 @@ public class MainVerticle extends AbstractVerticle {
           logger.error(permissions.encode() + "{}(user permissions) nor {}"
             + "(module permissions) do not contain {}",
           permissions.encode(), extraPermissions.encode(), o);
-          ctx.response().putHeader(XOkapiHeaders.MODULE_TOKENS, moduleTokens.encode())
+          ctx.response().putHeader(XOkapiHeaders.MODULE_TOKENS, moduleTokens.encode());
           endText(ctx, 403, "Access requires permission: " + o);
           return;
         }
@@ -741,7 +741,7 @@ public class MainVerticle extends AbstractVerticle {
       } catch(Exception e) {
         String message = String.format("Error creating access token: %s", e.getMessage());
         logger.error(message);
-        ctx.response().putHeader(XOkapiHeaders.MODULE_TOKENS, moduleTokens.encode())
+        ctx.response().putHeader(XOkapiHeaders.MODULE_TOKENS, moduleTokens.encode());
         endText(ctx, 500, "Error creating access token");
         return;
       }

--- a/src/test/java/org/folio/auth/authtokenmodule/AuthTokenTest.java
+++ b/src/test/java/org/folio/auth/authtokenmodule/AuthTokenTest.java
@@ -232,7 +232,7 @@ public class AuthTokenTest {
       .statusCode(202)
       .header("X-Okapi-Permissions", "[]")
       .header("X-Okapi-Module-Tokens", startsWith("{\"_\":\""))
-      .header("X-Okapi-Token", not(isEmptyString()))
+      .header("X-Okapi-Token", not(emptyString()))
       .header("Authorization", startsWith("Bearer "))
       .extract().response();
     final String noLoginToken = r.getHeader(XOkapiHeaders.TOKEN);
@@ -247,7 +247,7 @@ public class AuthTokenTest {
       .get("/foo")
       .then()
       .statusCode(403) // we don't have 'foo.req'
-      .header("X-Okapi-Module-Tokens", is(nullValue()));
+      .header("X-Okapi-Module-Tokens", not(emptyString()));
 
     // A request using the new nologin token with permissionDesired that will
     // succeed, but not give that perm
@@ -262,7 +262,7 @@ public class AuthTokenTest {
       .statusCode(202) // we don't have 'foo.req'
       .header("X-Okapi-Permissions", "[]")
       .header("X-Okapi-Module-Tokens", startsWith("{\"_\":\""))
-      .header("X-Okapi-Token", not(isEmptyString()));
+      .header("X-Okapi-Token", not(emptyString()));
 
     // A request with the nologin token, with some modulePermissions to be
     // included in a new token
@@ -277,7 +277,7 @@ public class AuthTokenTest {
       .then()
       .statusCode(202)
       .header("X-Okapi-Permissions", "[]")
-      .header("X-Okapi-Module-Tokens", not(isEmptyString()))
+      .header("X-Okapi-Module-Tokens", not(emptyString()))
       .extract().response();
     final String modTokens = r.getHeader("X-Okapi-Module-Tokens");
     JsonObject modtoks = new JsonObject(modTokens);
@@ -444,7 +444,7 @@ public class AuthTokenTest {
       .get("/bar")
       .then()
       .statusCode(400).body(containsString("Connection refused"))
-      .header("X-Okapi-Module-Tokens", is(nullValue()));
+      .header("X-Okapi-Module-Tokens", not(emptyString()));
     // used to be 401.. But connection refused is hardly forbidden..
 
     logger.info("Test /permss/users with bad status");


### PR DESCRIPTION
As X-Okapi-Module-Tokens should be returned even in case of errors
so that pre/post filters can be invoked with proper module token. See MODAT-38