### PR TITLE
Redundant web service request MODAT-117

### DIFF
--- a/src/main/java/org/folio/auth/authtokenmodule/impl/ModulePermissionsSource.java
+++ b/src/main/java/org/folio/auth/authtokenmodule/impl/ModulePermissionsSource.java
@@ -84,10 +84,9 @@ public class ModulePermissionsSource implements PermissionsSource {
       .compose(res -> {
         if (res.statusCode() == 404) {
           return Future.failedFuture( "User does not exist: " + userId);
-        }
-        else if (res.statusCode() != 200) {
+        } else if (res.statusCode() != 200) {
           String failMessage = "Unable to retrieve permissions (code " + res.statusCode() + "): " + res.bodyAsString();
-          logger.debug(failMessage);
+          logger.error(failMessage);
           return Future.failedFuture(failMessage);
         }
         // 200

--- a/src/main/java/org/folio/auth/authtokenmodule/impl/ModulePermissionsSource.java
+++ b/src/main/java/org/folio/auth/authtokenmodule/impl/ModulePermissionsSource.java
@@ -74,59 +74,38 @@ public class ModulePermissionsSource implements PermissionsSource {
   }
 
   private Future<JsonArray> getPermissionsForUser(String userId, String tenant, String okapiUrl,
-                                                  String requestToken, String requestId) {
+    String requestToken, String requestId) {
     logger.debug("getPermissionsForUser userid={}", userId);
-    String permUserRequestUrl = okapiUrl + "/perms/users?query=userId==" + userId;
-    logger.debug("Requesting permissions user object from URL at {}", permUserRequestUrl);
-    HttpRequest<Buffer> permUserReq = client.getAbs(permUserRequestUrl);
-    setHeaders(permUserReq, requestToken, tenant, requestId);
-    return permUserReq.send()
-        .compose(permUserRes -> {
-          if (permUserRes.statusCode() != 200) {
-            String message = "Expected return code 200, got " + permUserRes.statusCode()
-                + " : " + permUserRes.bodyAsString();
-            logger.error(message);
-            return Future.failedFuture(message);
-          }
-          JsonObject permUserResults = permUserRes.bodyAsJsonObject();
-          JsonArray permissionUsers = permUserResults.getJsonArray("permissionUsers");
-          if (permissionUsers.isEmpty()) {
-            return Future.failedFuture( "User does not exist: " + permUserRequestUrl);
-          }
-          JsonObject permUser = permissionUsers.getJsonObject(0);
-          final String requestUrl = okapiUrl + "/perms/users/" + permUser.getString("id") + "/permissions?expanded=true";
-          logger.debug("Requesting permissions from URL at {}", requestUrl);
-          HttpRequest<Buffer> req = client.getAbs(requestUrl);
-          setHeaders(req, requestToken, tenant, requestId);
-          return req.send()
-              .compose(res -> {
-                if (res.statusCode() == 404) {
-                  //In the event of a 404, that means that the permissions user
-                  //doesn't exist, so we'll return an empty list to indicate no permissions
-                  return Future.succeededFuture(new JsonArray());
-                }
-                if (res.statusCode() != 200) {
-                  String failMessage = "Unable to retrieve permissions (code " + res.statusCode() + "): " + res.bodyAsString();
-                  logger.debug(failMessage);
-                  return Future.failedFuture(failMessage);
-                }
-                // 200
-                JsonObject permissionsObject;
-                try {
-                  permissionsObject = res.bodyAsJsonObject();
-                } catch (Exception e) {
-                  logger.debug("Error parsing permissions object: {}", e.getMessage());
-                  permissionsObject = null;
-                }
-                if (permissionsObject != null && permissionsObject.getJsonArray("permissionNames") != null) {
-                  logger.debug("Got permissions");
-                  return Future.succeededFuture(permissionsObject.getJsonArray("permissionNames"));
-                } else {
-                  logger.error("Got malformed/empty permissions object");
-                  return Future.failedFuture("Got malformed/empty permissions object");
-                }
-              });
-        });
+    final String requestUrl = okapiUrl + "/perms/users/" + userId + "/permissions?expanded=true&indexField=userId";
+    logger.debug("Requesting permissions from URL at {}", requestUrl);
+    HttpRequest<Buffer> req = client.getAbs(requestUrl);
+    setHeaders(req, requestToken, tenant, requestId);
+    return req.send()
+      .compose(res -> {
+        if (res.statusCode() == 404) {
+          return Future.failedFuture( "User does not exist: " + userId);
+        }
+        else if (res.statusCode() != 200) {
+          String failMessage = "Unable to retrieve permissions (code " + res.statusCode() + "): " + res.bodyAsString();
+          logger.debug(failMessage);
+          return Future.failedFuture(failMessage);
+        }
+        // 200
+        JsonObject permissionsObject;
+        try {
+          permissionsObject = res.bodyAsJsonObject();
+        } catch (Exception e) {
+          logger.debug("Error parsing permissions object: {}", e.getMessage());
+          permissionsObject = null;
+        }
+        if (permissionsObject != null && permissionsObject.getJsonArray("permissionNames") != null) {
+          logger.debug("Got permissions");
+          return Future.succeededFuture(permissionsObject.getJsonArray("permissionNames"));
+        } else {
+          logger.error("Got malformed/empty permissions object");
+          return Future.failedFuture("Got malformed/empty permissions object");
+        }
+      });
   }
 
   private void setHeaders(HttpRequest<Buffer> req, String requestToken,

--- a/src/test/java/org/folio/auth/authtokenmodule/AuthTokenTest.java
+++ b/src/test/java/org/folio/auth/authtokenmodule/AuthTokenTest.java
@@ -35,7 +35,6 @@ import static org.junit.Assert.assertTrue;
 public class AuthTokenTest {
 
   private static final Logger logger = LogManager.getLogger("AuthTokenTest");
-  private static final String LS = System.lineSeparator();
   private static final String tenant = "Roskilde";
   private static HttpClient httpClient;
   private static TokenCreator tokenCreator;
@@ -449,32 +448,6 @@ public class AuthTokenTest {
       .header("X-Okapi-Module-Tokens", not(emptyString()));
     // used to be 401.. But connection refused is hardly forbidden..
 
-    logger.info("Test /perms/users with bad status");
-    PermsMock.handlePermsUsersStatusCode = 400;
-    given()
-      .header("X-Okapi-Tenant", tenant)
-      .header("X-Okapi-Request-Id", "1234")
-      .header("X-Okapi-Token", basicToken2)
-      .header("X-Okapi-Url", "http://localhost:" + mockPort)
-      .header("X-Okapi-Permissions-Desired", "extra.*bar")
-      .get("/bar")
-      .then()
-      .statusCode(400);
-    PermsMock.handlePermsUsersStatusCode = 200;
-
-    logger.info("Test /perms/users with bad response");
-    PermsMock.handlePermsUsersFail = true;
-    given()
-      .header("X-Okapi-Tenant", tenant)
-      .header("X-Okapi-Request-Id", "1234")
-      .header("X-Okapi-Token", basicToken2)
-      .header("X-Okapi-Url", "http://localhost:" + mockPort)
-      .header("X-Okapi-Permissions-Desired", "extra.*bar")
-      .get("/bar")
-      .then()
-      .statusCode(400);
-    PermsMock.handlePermsUsersFail = false;
-
     logger.info("Test with wildcard 400 /perms/users/id/permissions");
     PermsMock.handlePermsUsersPermissionsStatusCode = 400;
     given()
@@ -511,8 +484,7 @@ public class AuthTokenTest {
       .header("X-Okapi-Permissions-Desired", "extra.*bar")
       .get("/bar")
       .then()
-      .statusCode(202)
-      .header("X-Okapi-Permissions", "[]");
+      .statusCode(400);
     PermsMock.handlePermsUsersPermissionsStatusCode = 200;
 
     //pass a desired permission through as a wildcard

--- a/src/test/java/org/folio/auth/authtokenmodule/PermsMock.java
+++ b/src/test/java/org/folio/auth/authtokenmodule/PermsMock.java
@@ -18,10 +18,8 @@ public class PermsMock extends AbstractVerticle {
 
   private static final Logger logger = LogManager.getLogger("PermsMock");
 
-  public static int handlePermsUsersStatusCode = 200;
   public static int handlePermsUsersPermissionsStatusCode = 200;
   public static int handlePermsPermissionsStatusCode = 200;
-  public static boolean handlePermsUsersFail = false;
   public static boolean handlePermsUsersEmpty = false;
   public static boolean handlePermsUsersPermissionsFail = false;
   public static boolean handlePermsPermissionsFail = false;
@@ -38,7 +36,6 @@ public class PermsMock extends AbstractVerticle {
     HttpServer server = vertx.createHttpServer();
 
     router.route("/perms/users/:id/permissions").handler(this::handlePermUsersPermissions);
-    router.route("/perms/users").handler(this::handlePermsUsers);
     router.route("/perms/permissions").handler(this::handlePermsPermissions);
     router.route("/users/:id").handler(this::handleUsers);
     logger.info("Running PermsMock on port " + port);
@@ -60,33 +57,14 @@ public class PermsMock extends AbstractVerticle {
         .end(new JsonObject().put("active", true).encode());
   }
 
-  private void handlePermsUsers(RoutingContext context) {
-    if (handlePermsUsersFail) {
+  private void handlePermUsersPermissions(RoutingContext context) {
+    if (handlePermsUsersEmpty) {
       context.response()
-        .setStatusCode(handlePermsUsersStatusCode)
-        .putHeader("Content-type", "application/json")
-        .end("{");
+        .setStatusCode(404)
+        .putHeader("Content-Type", "text/plain")
+        .end("User not found");
       return;
     }
-    JsonArray ar = new JsonArray();
-    if (!handlePermsUsersEmpty) {
-      ar.add(new JsonObject()
-        .put("id", "773cb9d1-1e4f-416f-ba16-686ddeb6c789")
-        .put("userId", "007d31d2-1441-4291-9bb8-d6e2c20e399a")
-        .put("permissions", new JsonArray()
-          .add("extra.foobar")
-          .add("extra.foofish")
-        )
-      );
-    }
-    JsonObject output = new JsonObject().put("permissionUsers", ar);
-    context.response()
-      .setStatusCode(handlePermsUsersStatusCode)
-      .putHeader("Content-Type", "application/json")
-      .end(output.encode());
-  }
-
-  private void handlePermUsersPermissions(RoutingContext context) {
     if (handlePermsUsersPermissionsFail) {
       context.response()
         .setStatusCode(handlePermsUsersPermissionsStatusCode)


### PR DESCRIPTION
When mod-authtoken fetches permissions for a user it calls

/perms/users?query=userId=={userId}
followed by:

/perms/users/{permUserId}/permissions?expanded=true
This can be changed to one call:

/perms/users/{userId}/permissions?expanded=true&indexField=userId