### PR TITLE
Always invoke filter (except for admin health).

### DIFF
--- a/src/main/java/org/folio/auth/authtokenmodule/AuthorizeApi.java
+++ b/src/main/java/org/folio/auth/authtokenmodule/AuthorizeApi.java
@@ -94,15 +94,17 @@ public class AuthorizeApi implements RouterCreator, TenantInitHooks {
   public AuthorizeApi(Vertx vertx, TokenCreator tc) {
     authRoutingEntryList = new ArrayList<>();
     authRoutingEntryList.add(new AuthRoutingEntry("/token",
-        new String[] { SIGN_TOKEN_PERMISSION }, this::handleSignToken));
+      new String[] { SIGN_TOKEN_PERMISSION }, this::handleSignToken));
     authRoutingEntryList.add(new AuthRoutingEntry("/refreshtoken",
-        new String[] { SIGN_REFRESH_TOKEN_PERMISSION }, this::handleSignRefreshToken));
+      new String[] { SIGN_REFRESH_TOKEN_PERMISSION }, this::handleSignRefreshToken));
     authRoutingEntryList.add(new AuthRoutingEntry("/refresh",
-        new String[] {}, this::handleRefresh));
+      new String[] {}, this::handleRefresh));
     authRoutingEntryList.add(new AuthRoutingEntry("/encrypted-token/create",
-        new String[] {}, this::handleSignEncryptedToken));
+      new String[] {}, this::handleSignEncryptedToken));
     authRoutingEntryList.add(new AuthRoutingEntry("/encrypted-token/decode",
-        new String[] {}, this::handleDecodeEncryptedToken));
+      new String[] {}, this::handleDecodeEncryptedToken));
+    authRoutingEntryList.add(new AuthRoutingEntry("/_/tenant",
+      new String[] {}, RoutingContext::next));
 
     tokenCreator = tc;
 

--- a/src/main/java/org/folio/auth/authtokenmodule/MainVerticle.java
+++ b/src/main/java/org/folio/auth/authtokenmodule/MainVerticle.java
@@ -48,11 +48,9 @@ public class MainVerticle extends AbstractVerticle {
 
     var authorizeApi = new AuthorizeApi(vertx, tokenCreator);
     RouterCreator[] routerCreators = {
-      // NOTE Adding these in this order is important, otherwise the filter in AuthorizeApi will
-      // not let the Tenant2Api do its work.
-      new HealthApi(),
+      new HealthApi(), // called regardless of tenant
+      authorizeApi,  // filtering and hand-coded handlers (Tenant API is postponed)
       new Tenant2Api(authorizeApi),
-      authorizeApi,
     };
     HttpServerOptions so = new HttpServerOptions().setHandle100ContinueAutomatically(true);
 

--- a/src/test/java/org/folio/auth/authtokenmodule/AuthTokenTest.java
+++ b/src/test/java/org/folio/auth/authtokenmodule/AuthTokenTest.java
@@ -652,7 +652,7 @@ public class AuthTokenTest {
       .body(payloadDummy.encode())
       .post("/token")
       .then()
-      .statusCode(403).body(containsString("Missing permissions to access endpoint '/token'"));
+      .statusCode(401).body(containsString("Missing required module-level permissions for endpoint '/token': auth.signtoken"));
 
     logger.info("POST signing request with good token, no payload");
     given()
@@ -1040,7 +1040,7 @@ public class AuthTokenTest {
       .body(is("OK"));
   }
 
-  private String getMagicPermission(String endpoint) {
+  private static String getMagicPermission(String endpoint) {
     return String.format("%s.execute", Base64.encode(endpoint));
   }
 
@@ -1200,6 +1200,8 @@ public class AuthTokenTest {
     ExtractableResponse<Response> response = RestAssured.given()
         .header(XOkapiHeaders.TENANT, tenant)
         .header(XOkapiHeaders.URL, "http://localhost:" + port)
+        .header("X-Okapi-Permissions", "[\"" + getMagicPermission("/_/tenant") + "\"]")
+        .header("X-Okapi-Url", "http://localhost:" + freePort)
         .header("Content-Type", "application/json")
         .body(tenantAttributes.encode())
         .post("/_/tenant")
@@ -1217,6 +1219,8 @@ public class AuthTokenTest {
 
     RestAssured.given()
         .header(XOkapiHeaders.TENANT, tenant)
+        .header("X-Okapi-Url", "http://localhost:" + freePort)
+        .header("X-Okapi-Permissions", "[\"" + getMagicPermission("/_/tenant") + "\"]")
         .get(location + "?wait=10000")
         .then().statusCode(200)
         .body("complete", is(true));


### PR DESCRIPTION
The tenant call when recognized is just postponed to be handled later.