### PR TITLE
MODAT-125: Update dependencies (CVE-2021-27568, CVE-2021-31684)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>4.2.4</version>
+        <version>4.2.5</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -83,7 +83,7 @@
     <dependency>
       <groupId>org.folio.okapi</groupId>
       <artifactId>okapi-common</artifactId>
-      <version>4.12.0</version>
+      <version>4.13.0</version>
     </dependency>
     <dependency>
       <groupId>org.folio</groupId>
@@ -93,7 +93,7 @@
     <dependency>
       <groupId>com.nimbusds</groupId>
       <artifactId>nimbus-jose-jwt</artifactId>
-      <version>7.9</version>
+      <version>9.20</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
@@ -117,13 +117,13 @@
     <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
-      <version>4.4.0</version>
+      <version>4.5.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>3.3.3</version>
+      <version>4.3.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Update Vert.x from 4.2.4 to 4.2.5 fixing pool bugs: https://github.com/vert-x3/wiki/wiki/4.2.5-Release-Notes

Update nimbus-jose-jwt from 7.9 to 9.20;
this indirectly removes the dependency on net.minidev:json-smart:2.3 and fixes denial of service (DoS) vulnerability reports: https://nvd.nist.gov/vuln/detail/CVE-2021-27568 https://nvd.nist.gov/vuln/detail/CVE-2021-31684

Update all other dependencies to latest stable versions:
* okapi-common from 4.12.0 to 4.13.0
* rest-assured from 4.4.0 to 4.5.1
* mockito-core from 3.3.3 to 4.3.1