### PR TITLE
MODAT-128: jwt.signing.key hint on BadSignatureException

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The expiration time is hard-coded:
 
 mod-authtoken supports a number of command line options as system properties, set by passing `-D<property.name>=<value>` to the jar when loading.
 
-* `jwt.signing.key` - A passphrase to use as a signing key. Setting this property for all instances of the module allows mod-authtoken to be clustered
+* `jwt.signing.key` - A passphrase to use as a signing key. If not set a random key is generated on each module restart invalidating all previously issued tokens. For clustering all instances of mod-authtoken must be configured to use the same key.
 * `perm.lookup.timeout` - Timeout for lookups to mod-permissions in seconds. Defaults to 10.
 * `user.cache.seconds` - Time to cache user permissions in seconds. Defaults to 60.
 * `user.cache.purge.seconds` - Time before a user is purged from the permissions cache in seconds. Defaults to 43200 (12 hours).

--- a/src/main/java/org/folio/auth/authtokenmodule/tokens/Token.java
+++ b/src/main/java/org/folio/auth/authtokenmodule/tokens/Token.java
@@ -223,7 +223,10 @@ public abstract class Token {
     } catch (JOSEException j) {
       throw new TokenValidationException(invalidTokenMsg, j, 401);
     } catch (BadSignatureException b) {
-      throw new TokenValidationException(invalidTokenMsg, b, 401);
+      final String msg = "Invalid token signature. "
+          + "This might have been caused by a mod-authtoken restart if jwt.signing.key is not set, "
+          + "or by running multiple mod-authtoken instances without setting the same jwt.signing.key.";
+      throw new TokenValidationException(msg, b, 401);
     }
 
     String tokenType = claims.getString("type");

--- a/src/test/java/org/folio/auth/authtokenmodule/AuthTokenTest.java
+++ b/src/test/java/org/folio/auth/authtokenmodule/AuthTokenTest.java
@@ -450,7 +450,7 @@ public class AuthTokenTest {
         .statusCode(401)
         .assertThat().body(containsString("not active"));
 
-    logger.info("Test with basicBadToken");
+    logger.info("Test with badAccessToken created with wrong key");
     given()
         .header("X-Okapi-Tenant", tenant)
         .header("X-Okapi-Token", badAccessToken)
@@ -458,7 +458,8 @@ public class AuthTokenTest {
         .header("X-Okapi-User-Id", userUUID)
         .get("/bar")
         .then()
-        .statusCode(401);
+        .statusCode(401)
+        .body(is("Invalid token"));
 
     // fail with a bad token
     logger.info("Test with bad token format");
@@ -469,7 +470,8 @@ public class AuthTokenTest {
         .header("X-Okapi-User-Id", "1234567")
         .get("/bar")
         .then()
-        .statusCode(401);
+        .statusCode(401)
+        .body(is("Invalid token"));
 
     logger.info("Test with wildcard permission - bad X-Okapi-Url");
     given()


### PR DESCRIPTION
As a sysop I would like to read some hint in the log how to fix the configuration when "Invalid token" might be caused by a wrong jwt.signing.key.

Use case 1:

Given that jwt.signing.key is not set and mod-authtoken is restarted

When using a token that has been issued before the restart that causes an "Invalid token" error

Then the log should indicate this it might be caused by the mod-authtoken restart.

Use case 2:

Given that a cluster of multiple instances of mod-authtoken has been configured with different jwt.signing.key values.

When using a token that has been issued by an instance with different key and getting an "Invalid token" error.

Then the log should indicate this it might be caused by different keys.