### PR TITLE
[MODAT-148]. Allow cross tenant requests only when special system property variable presented

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ mod-authtoken supports a number of command line options as system properties, se
 * `log.level` - Module log level.
 * `port` - Port the module will listen on. Defaults to 8081.
 * `cache.permissions` - Boolean controlling the permissions cache. Defaults to `true`.
+* `allow.cross.tenant.requests` - Boolean to allow (in consortia setups) or deny cross tenant requests. Defaults to `false`.
 
 # Custom Headers
 

--- a/src/main/java/org/folio/auth/authtokenmodule/tokens/Token.java
+++ b/src/main/java/org/folio/auth/authtokenmodule/tokens/Token.java
@@ -290,6 +290,9 @@ public abstract class Token {
   }
 
   protected Future<Token> validateTenantMismatch(TokenValidationContext context) {
+    if (!context.isAllowCrossTenantRequests()) {
+      return Future.failedFuture(new TokenValidationException(TENANT_MISMATCH_EXCEPTION_MESSAGE, 403));
+    }
     return isCrossTenantRequest(context).compose(aResult -> Boolean.TRUE.equals(aResult) ? Future.succeededFuture(this)
       : Future.failedFuture(new TokenValidationException(TENANT_MISMATCH_EXCEPTION_MESSAGE, 403)));
   }

--- a/src/main/java/org/folio/auth/authtokenmodule/tokens/TokenValidationContext.java
+++ b/src/main/java/org/folio/auth/authtokenmodule/tokens/TokenValidationContext.java
@@ -63,6 +63,7 @@ public class TokenValidationContext {
 
   /**
    * Return flag is cross tenant requests allowed, it uses system property 'allow.cross.tenant.requests'.
+   *
    * @return true if system property 'allow.cross.tenant.requests' equals to 'true' or false if
    * it is not set or equals to 'false'
    */
@@ -71,9 +72,9 @@ public class TokenValidationContext {
   }
 
   public TokenValidationContext(HttpServerRequest httpServerRequest,
-                                TokenCreator tokenCreator,
-                                String tokenToValidate,
-                                UserService userService) {
+      TokenCreator tokenCreator,
+      String tokenToValidate,
+      UserService userService) {
     this.httpServerRequest = httpServerRequest;
     this.tokenCreator = tokenCreator;
     this.tokenToValidate = tokenToValidate;

--- a/src/main/java/org/folio/auth/authtokenmodule/tokens/TokenValidationContext.java
+++ b/src/main/java/org/folio/auth/authtokenmodule/tokens/TokenValidationContext.java
@@ -1,5 +1,6 @@
 package org.folio.auth.authtokenmodule.tokens;
 
+import org.apache.commons.lang3.BooleanUtils;
 import org.folio.auth.authtokenmodule.TokenCreator;
 import org.folio.auth.authtokenmodule.UserService;
 import org.folio.auth.authtokenmodule.storage.TokenStore;
@@ -17,6 +18,7 @@ public class TokenValidationContext {
   private TokenCreator tokenCreator;
   private TokenStore tokenStore;
   private UserService userService;
+  private boolean allowCrossTenantRequests;
 
   /**
    * Gets the http request associated with the validation context.
@@ -51,18 +53,32 @@ public class TokenValidationContext {
     return tokenStore;
   }
 
+  /**
+   * Gets a reference to the user service.
+   * @return user service
+   */
   public UserService getUserService() {
     return userService;
   }
 
+  /**
+   * Return flag is cross tenant requests allowed, it uses system property 'allow.cross.tenant.requests'.
+   * @return true if system property 'allow.cross.tenant.requests' equals to 'true' or false if
+   * it is not set or equals to 'false'
+   */
+  public boolean isAllowCrossTenantRequests() {
+    return allowCrossTenantRequests;
+  }
+
   public TokenValidationContext(HttpServerRequest httpServerRequest,
-      TokenCreator tokenCreator,
-      String tokenToValidate,
-      UserService userService) {
+                                TokenCreator tokenCreator,
+                                String tokenToValidate,
+                                UserService userService) {
     this.httpServerRequest = httpServerRequest;
     this.tokenCreator = tokenCreator;
     this.tokenToValidate = tokenToValidate;
     this.userService = userService;
+    this.allowCrossTenantRequests = BooleanUtils.toBoolean(System.getProperty("allow.cross.tenant.requests"));
   }
 
   public TokenValidationContext(HttpServerRequest httpServerRequest,
@@ -70,10 +86,7 @@ public class TokenValidationContext {
       String tokenToValidate,
       TokenStore tokenStore,
       UserService userService) {
-    this.httpServerRequest = httpServerRequest;
-    this.tokenCreator = tokenCreator;
-    this.tokenToValidate = tokenToValidate;
+    this(httpServerRequest, tokenCreator, tokenToValidate, userService);
     this.tokenStore = tokenStore;
-    this.userService = userService;
   }
 }

--- a/src/test/java/org/folio/auth/authtokenmodule/AuthTokenTest.java
+++ b/src/test/java/org/folio/auth/authtokenmodule/AuthTokenTest.java
@@ -382,7 +382,32 @@ public class AuthTokenTest {
         .statusCode(403)
         .body(containsString("Invalid token"));
 
-    logger.info("The test cross-tenant request is permitted when /user-tenants isn't empty");
+    System.setProperty("allow.cross.tenant.requests", "");
+    logger.info("The test cross-tenant request is denied when system property 'allow.cross.tenant.requests' is not set");
+    given()
+      .header("X-Okapi-Tenant", "test-tenant-1")
+      .header("X-Okapi-Token", barToken)
+      .header("X-Okapi-Url", "http://localhost:" + freePort)
+      .header("X-Okapi-Permissions-Desired", "bar.first")
+      .header("X-Okapi-Permissions-Required", "bar.second")
+      .get("/bar")
+      .then()
+      .statusCode(403);
+
+    System.setProperty("allow.cross.tenant.requests", "false");
+    logger.info("The test cross-tenant request is denied when system property 'allow.cross.tenant.requests' is 'false'");
+    given()
+      .header("X-Okapi-Tenant", "test-tenant-1")
+      .header("X-Okapi-Token", barToken)
+      .header("X-Okapi-Url", "http://localhost:" + freePort)
+      .header("X-Okapi-Permissions-Desired", "bar.first")
+      .header("X-Okapi-Permissions-Required", "bar.second")
+      .get("/bar")
+      .then()
+      .statusCode(403);
+
+    System.setProperty("allow.cross.tenant.requests", "true");
+    logger.info("The test cross-tenant request is permitted when system property 'allow.cross.tenant.requests' is 'true' and /user-tenants isn't empty");
     given()
       .header("X-Okapi-Tenant", "test-tenant-1")
       .header("X-Okapi-Token", barToken)


### PR DESCRIPTION
https://issues.folio.org/browse/MODAT-148

**Overview:**
Currently cross tenant requests allowed only in case when core mod-users /user-tenants response has total > 0 , it means that corresponding tenant added to consortium and we allow cross-tenant request. One more level of protection will be added by using a new system property:
'allow.cross.tenant.requests'. If this propertyis not set - cross tenant requests will be denied, in another case - standard checking of /user-tenant endpoint should be done as it doing now.

**Implementation Approach:**
ValidateTenantMismatch method is adjusted to look into presence of 'allow.cross.tenant.requests' [Code](https://github.com/folio-org/mod-authtoken/blob/master/src/main/java/org/folio/auth/authtokenmodule/tokens/Token.java#L292)

If system property is missed - request will be denied or check of /user-tenants endpoint will be done as before.