### PR TITLE
Add running application in consortia mode locally without redeploying mod-authtoken

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -101,7 +101,7 @@
     },
     "env": [
       { "name": "JAVA_OPTIONS",
-        "value": "-XX:MaxRAMPercentage=66.0 -Dcache.permissions=true"
+        "value": "-XX:MaxRAMPercentage=66.0 -Dcache.permissions=true -Dallow.cross.tenant.requests=true"
       }
     ]
   }


### PR DESCRIPTION
We are trying to simplify local development in multi-tenant mode. Now mod-authtoken in local vagrant does not support cross tenant requests, so to run some consortia functionality and karate tests locally we need to re-run mod-authtoken with property allow.cross.tenant.requests.enabled.
We want to minimize effort for local setup, especially when redeploying a mod-auth token is not a very trivial process.
Vagrant build should take this property from module descriptor, hosting providers do not use module descriptor defaults, they overriding  with their custom values, so this property will not be set by default
