### PR TITLE
MODAT-149. Make RTR compatible with ECS

### DIFF
--- a/src/main/java/org/folio/auth/authtokenmodule/apis/RouteApi.java
+++ b/src/main/java/org/folio/auth/authtokenmodule/apis/RouteApi.java
@@ -226,7 +226,7 @@ public class RouteApi extends Api implements RouterCreator, TenantInitHooks {
       var refreshTokenStore = new RefreshTokenStore(vertx, tenant);
 
       var context = new TokenValidationContext(ctx.request(), tokenCreator, encryptedJWE, refreshTokenStore, userService);
-      Future<Token> tokenValidationResult = Token.validateTokenType(parsedToken, context);
+      Future<Token> tokenValidationResult = Token.validate(parsedToken, context);
 
       tokenValidationResult.onFailure(e -> handleTokenValidationFailure(e, ctx));
 

--- a/src/main/java/org/folio/auth/authtokenmodule/apis/RouteApi.java
+++ b/src/main/java/org/folio/auth/authtokenmodule/apis/RouteApi.java
@@ -221,7 +221,7 @@ public class RouteApi extends Api implements RouterCreator, TenantInitHooks {
     try {
       JsonObject requestJson = ctx.body().asJsonObject();
       String encryptedJWE = requestJson.getString(Token.REFRESH_TOKEN);
-      Token parsedToken = Token.validateTokenContent(encryptedJWE, tokenCreator);
+      Token parsedToken = Token.parse(encryptedJWE, tokenCreator);
       String tenant = StringUtils.defaultIfBlank(parsedToken.getTenant(), ctx.request().headers().get(XOkapiHeaders.TENANT));
       var refreshTokenStore = new RefreshTokenStore(vertx, tenant);
 

--- a/src/main/java/org/folio/auth/authtokenmodule/tokens/RefreshToken.java
+++ b/src/main/java/org/folio/auth/authtokenmodule/tokens/RefreshToken.java
@@ -91,9 +91,4 @@ public class RefreshToken extends Token {
       .compose(refreshTokenStore -> refreshTokenStore.checkTokenNotRevoked(this))
       .map(this);
   }
-
-  @Override
-  protected Future<Token> validateTenantMismatch(TokenValidationContext context) {
-    return Future.failedFuture(new TokenValidationException(TENANT_MISMATCH_EXCEPTION_MESSAGE, 403));
-  }
 }

--- a/src/main/java/org/folio/auth/authtokenmodule/tokens/Token.java
+++ b/src/main/java/org/folio/auth/authtokenmodule/tokens/Token.java
@@ -82,15 +82,41 @@ public abstract class Token {
   public static Future<Token> validate(TokenValidationContext context) {
     Token token;
     try {
-      token = parse(context.getTokenToValidate(), context.getTokenCreator());
+      token = validateTokenContent(context.getTokenToValidate(), context.getTokenCreator());
     } catch (TokenValidationException e) {
       return Future.failedFuture(e);
-    } catch (Exception e) {
-      return Future.failedFuture(new TokenValidationException("Unexpected token parse exception", e, 500));
     }
 
     // Call the validateContext implementation of the underlying token type (AccessToken,
     // RefreshToken, etc.). See those classes for the validation logic specific to each type.
+    return validateTokenType(token, context);
+  }
+
+  /**
+   * Validates if token payload is correct and parsed successfully.
+   * @param tokenToValidate the token content payload to validate
+   * @param tokenCreator the token creator
+   * @return token if token content parsed successfully
+   * @throws TokenValidationException if token content could not be parsed
+   */
+  public static Token validateTokenContent(String tokenToValidate, TokenCreator tokenCreator) throws TokenValidationException {
+    try {
+      return parse(tokenToValidate, tokenCreator);
+    } catch (TokenValidationException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new TokenValidationException("Unexpected token parse exception", e, 500);
+    }
+  }
+
+  /**
+   * Validates token type, each underlying token type token can have the specific rules to check if token valid.
+   * See those classes for the validation logic specific to each type.
+   * @param token the token to validate
+   * @param context the context used for token validation
+   * @return future with token is validation was successful or failed future otherwise
+   */
+  public static Future<Token> validateTokenType(Token token, TokenValidationContext context) {
     return token.validateContext(context);
   }
 

--- a/src/main/java/org/folio/auth/authtokenmodule/tokens/Token.java
+++ b/src/main/java/org/folio/auth/authtokenmodule/tokens/Token.java
@@ -82,7 +82,7 @@ public abstract class Token {
   public static Future<Token> validate(TokenValidationContext context) {
     Token token;
     try {
-      token = validateTokenContent(context.getTokenToValidate(), context.getTokenCreator());
+      token = parse(context.getTokenToValidate(), context.getTokenCreator());
     } catch (TokenValidationException e) {
       return Future.failedFuture(e);
     }
@@ -90,23 +90,6 @@ public abstract class Token {
     // Call the validateContext implementation of the underlying token type (AccessToken,
     // RefreshToken, etc.). See those classes for the validation logic specific to each type.
     return validateTokenType(token, context);
-  }
-
-  /**
-   * Validates if token payload is correct and parsed successfully.
-   * @param tokenToValidate the token content payload to validate
-   * @param tokenCreator the token creator
-   * @return token if token content parsed successfully
-   * @throws TokenValidationException if token content could not be parsed
-   */
-  public static Token validateTokenContent(String tokenToValidate, TokenCreator tokenCreator) throws TokenValidationException {
-    try {
-      return parse(tokenToValidate, tokenCreator);
-    } catch (TokenValidationException e) {
-      throw e;
-    } catch (Exception e) {
-      throw new TokenValidationException("Unexpected token parse exception", e, 500);
-    }
   }
 
   /**

--- a/src/main/java/org/folio/auth/authtokenmodule/tokens/Token.java
+++ b/src/main/java/org/folio/auth/authtokenmodule/tokens/Token.java
@@ -85,6 +85,8 @@ public abstract class Token {
       token = parse(context.getTokenToValidate(), context.getTokenCreator());
     } catch (TokenValidationException e) {
       return Future.failedFuture(e);
+    } catch (Exception e) {
+      return Future.failedFuture(new TokenValidationException("Unexpected token parse exception", e, 500));
     }
 
     // Call the validateContext implementation of the underlying token type (AccessToken,

--- a/src/main/java/org/folio/auth/authtokenmodule/tokens/Token.java
+++ b/src/main/java/org/folio/auth/authtokenmodule/tokens/Token.java
@@ -91,17 +91,17 @@ public abstract class Token {
 
     // Call the validateContext implementation of the underlying token type (AccessToken,
     // RefreshToken, etc.). See those classes for the validation logic specific to each type.
-    return validateTokenType(token, context);
+    return validate(token, context);
   }
 
   /**
-   * Validates token type, each underlying token type token can have the specific rules to check if token valid.
+   * Validates already parsed token, each underlying token type token can have the specific rules to check if token valid.
    * See those classes for the validation logic specific to each type.
    * @param token the token to validate
    * @param context the context used for token validation
    * @return future with token is validation was successful or failed future otherwise
    */
-  public static Future<Token> validateTokenType(Token token, TokenValidationContext context) {
+  public static Future<Token> validate(Token token, TokenValidationContext context) {
     return token.validateContext(context);
   }
 

--- a/src/test/java/org/folio/auth/authtokenmodule/AuthTokenTest.java
+++ b/src/test/java/org/folio/auth/authtokenmodule/AuthTokenTest.java
@@ -6,6 +6,7 @@ import io.restassured.response.Response;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.util.Base64;
 
+import io.restassured.response.ValidatableResponse;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.json.JsonArray;
@@ -134,7 +135,6 @@ public class AuthTokenTest {
     .onComplete(context.asyncAssertSuccess(y -> {
         var tenantAttributes = new JsonObject().put("module_to", "mod-authtoken-1.0.0");
         initializeTenantForTokenStore(tenant, tenantAttributes);
-        //initializeTenantForTokenStore(memberTenant, tenantAttributes);
     }));
   }
 
@@ -915,20 +915,7 @@ public class AuthTokenTest {
     public void testRefreshToken() throws JOSEException, ParseException {
       logger.info("POST signing request for a refresh token");
 
-      var response = given()
-          .header("X-Okapi-Tenant", tenant)
-          .header("X-Okapi-Token", accessToken)
-          .header("X-Okapi-Url", "http://localhost:" + freePort)
-          .header("Content-type", "application/json")
-          .header("X-Okapi-Permissions", "[\"" + getMagicPermission("/token/sign") + "\"]")
-          .body(new JsonObject().put("payload", payloadSigningRequest).encode())
-          .post("/token/sign")
-          .then()
-          .statusCode(201)
-          .contentType("application/json")
-          .body("$", hasKey(Token.ACCESS_TOKEN_EXPIRATION))
-          .body("$", hasKey(Token.REFRESH_TOKEN_EXPIRATION));
-
+      var response = getSignTokenResponse();
       String rt = response.extract().path("refreshToken");
       String at = response.extract().path("accessToken");
 
@@ -1019,20 +1006,7 @@ public class AuthTokenTest {
     public void testRefreshTokenWhenCrossTenantRequestsDeniedBecauseOfSystemPropertyNotSet() {
       logger.info("POST signing request for a refresh token");
 
-      var response = given()
-        .header("X-Okapi-Tenant", tenant)
-        .header("X-Okapi-Token", accessToken)
-        .header("X-Okapi-Url", "http://localhost:" + freePort)
-        .header("Content-type", "application/json")
-        .header("X-Okapi-Permissions", "[\"" + getMagicPermission("/token/sign") + "\"]")
-        .body(new JsonObject().put("payload", payloadSigningRequest).encode())
-        .post("/token/sign")
-        .then()
-        .statusCode(201)
-        .contentType("application/json")
-        .body("$", hasKey(Token.ACCESS_TOKEN_EXPIRATION))
-        .body("$", hasKey(Token.REFRESH_TOKEN_EXPIRATION));
-
+      var response = getSignTokenResponse();
       String rt = response.extract().path("refreshToken");
       String at = response.extract().path("accessToken");
 
@@ -1056,20 +1030,7 @@ public class AuthTokenTest {
     public void testRefreshTokenWhenCrossTenantRequestsDeniedBecauseOfTenantNotInConsortia() {
       logger.info("POST signing request for a refresh token");
 
-      var response = given()
-        .header("X-Okapi-Tenant", tenant)
-        .header("X-Okapi-Token", accessToken)
-        .header("X-Okapi-Url", "http://localhost:" + freePort)
-        .header("Content-type", "application/json")
-        .header("X-Okapi-Permissions", "[\"" + getMagicPermission("/token/sign") + "\"]")
-        .body(new JsonObject().put("payload", payloadSigningRequest).encode())
-        .post("/token/sign")
-        .then()
-        .statusCode(201)
-        .contentType("application/json")
-        .body("$", hasKey(Token.ACCESS_TOKEN_EXPIRATION))
-        .body("$", hasKey(Token.REFRESH_TOKEN_EXPIRATION));
-
+      var response = getSignTokenResponse();
       String rt = response.extract().path("refreshToken");
       String at = response.extract().path("accessToken");
 
@@ -1094,20 +1055,7 @@ public class AuthTokenTest {
     public void testRefreshTokenWhenCrossTenantRequestsAllowed() {
       logger.info("POST signing request for a refresh token");
 
-      var response = given()
-        .header("X-Okapi-Tenant", tenant)
-        .header("X-Okapi-Token", accessToken)
-        .header("X-Okapi-Url", "http://localhost:" + freePort)
-        .header("Content-type", "application/json")
-        .header("X-Okapi-Permissions", "[\"" + getMagicPermission("/token/sign") + "\"]")
-        .body(new JsonObject().put("payload", payloadSigningRequest).encode())
-        .post("/token/sign")
-        .then()
-        .statusCode(201)
-        .contentType("application/json")
-        .body("$", hasKey(Token.ACCESS_TOKEN_EXPIRATION))
-        .body("$", hasKey(Token.REFRESH_TOKEN_EXPIRATION));
-
+      var response = getSignTokenResponse();
       String rt = response.extract().path("refreshToken");
       String at = response.extract().path("accessToken");
 
@@ -1124,6 +1072,22 @@ public class AuthTokenTest {
         .post("/token/refresh")
         .then()
         .statusCode(201);
+    }
+
+    private ValidatableResponse getSignTokenResponse() {
+      return given()
+        .header("X-Okapi-Tenant", tenant)
+        .header("X-Okapi-Token", accessToken)
+        .header("X-Okapi-Url", "http://localhost:" + freePort)
+        .header("Content-type", "application/json")
+        .header("X-Okapi-Permissions", "[\"" + getMagicPermission("/token/sign") + "\"]")
+        .body(new JsonObject().put("payload", payloadSigningRequest).encode())
+        .post("/token/sign")
+        .then()
+        .statusCode(201)
+        .contentType("application/json")
+        .body("$", hasKey(Token.ACCESS_TOKEN_EXPIRATION))
+        .body("$", hasKey(Token.REFRESH_TOKEN_EXPIRATION));
     }
 
     @Test

--- a/src/test/java/org/folio/auth/authtokenmodule/AuthTokenTest.java
+++ b/src/test/java/org/folio/auth/authtokenmodule/AuthTokenTest.java
@@ -57,6 +57,7 @@ public class AuthTokenTest {
 
   private static final Logger logger = LogManager.getLogger("AuthTokenTest");
   private static final String tenant = "roskilde";
+  private static final String memberTenant = "test-tenant-1";
   private static TokenCreator tokenCreator;
   private static String userUUID = "007d31d2-1441-4291-9bb8-d6e2c20e399a";
   private static String accessToken;
@@ -133,6 +134,7 @@ public class AuthTokenTest {
     .onComplete(context.asyncAssertSuccess(y -> {
         var tenantAttributes = new JsonObject().put("module_to", "mod-authtoken-1.0.0");
         initializeTenantForTokenStore(tenant, tenantAttributes);
+        //initializeTenantForTokenStore(memberTenant, tenantAttributes);
     }));
   }
 
@@ -1011,6 +1013,117 @@ public class AuthTokenTest {
           .get("/bar")
           .then()
           .statusCode(202);
+    }
+
+    @Test
+    public void testRefreshTokenWhenCrossTenantRequestsDeniedBecauseOfSystemPropertyNotSet() {
+      logger.info("POST signing request for a refresh token");
+
+      var response = given()
+        .header("X-Okapi-Tenant", tenant)
+        .header("X-Okapi-Token", accessToken)
+        .header("X-Okapi-Url", "http://localhost:" + freePort)
+        .header("Content-type", "application/json")
+        .header("X-Okapi-Permissions", "[\"" + getMagicPermission("/token/sign") + "\"]")
+        .body(new JsonObject().put("payload", payloadSigningRequest).encode())
+        .post("/token/sign")
+        .then()
+        .statusCode(201)
+        .contentType("application/json")
+        .body("$", hasKey(Token.ACCESS_TOKEN_EXPIRATION))
+        .body("$", hasKey(Token.REFRESH_TOKEN_EXPIRATION));
+
+      String rt = response.extract().path("refreshToken");
+      String at = response.extract().path("accessToken");
+
+      System.setProperty("allow.cross.tenant.requests", "false");
+      logger.info("POST refresh token to get a new refresh and access token with allow.cross.tenant.requests=false");
+
+      given()
+        .header("X-Okapi-Tenant", memberTenant)
+        .header("X-Okapi-Token", at)
+        .header("X-Okapi-Url", "http://localhost:" + freePort)
+        .header("Content-type", "application/json")
+        .header("X-Okapi-Permissions", "[\"" + getMagicPermission("/token/refresh") + "\"]")
+        .body(new JsonObject().put("refreshToken", rt).encode())
+        .post("/token/refresh")
+        .then()
+        .statusCode(403)
+        .body(containsString("Invalid token"));;
+    }
+
+    @Test
+    public void testRefreshTokenWhenCrossTenantRequestsDeniedBecauseOfTenantNotInConsortia() {
+      logger.info("POST signing request for a refresh token");
+
+      var response = given()
+        .header("X-Okapi-Tenant", tenant)
+        .header("X-Okapi-Token", accessToken)
+        .header("X-Okapi-Url", "http://localhost:" + freePort)
+        .header("Content-type", "application/json")
+        .header("X-Okapi-Permissions", "[\"" + getMagicPermission("/token/sign") + "\"]")
+        .body(new JsonObject().put("payload", payloadSigningRequest).encode())
+        .post("/token/sign")
+        .then()
+        .statusCode(201)
+        .contentType("application/json")
+        .body("$", hasKey(Token.ACCESS_TOKEN_EXPIRATION))
+        .body("$", hasKey(Token.REFRESH_TOKEN_EXPIRATION));
+
+      String rt = response.extract().path("refreshToken");
+      String at = response.extract().path("accessToken");
+
+      System.setProperty("allow.cross.tenant.requests", "true");
+      String notConsortiumTenant = "notConsortiumTenant";
+      logger.info("POST refresh token to get a new refresh and access token with allow.cross.tenant.requests=true, but not for consortium tenant(/user-tenant returns empty response)");
+
+      given()
+        .header("X-Okapi-Tenant", notConsortiumTenant)
+        .header("X-Okapi-Token", at)
+        .header("X-Okapi-Url", "http://localhost:" + freePort)
+        .header("Content-type", "application/json")
+        .header("X-Okapi-Permissions", "[\"" + getMagicPermission("/token/refresh") + "\"]")
+        .body(new JsonObject().put("refreshToken", rt).encode())
+        .post("/token/refresh")
+        .then()
+        .statusCode(403)
+        .body(containsString("Invalid token"));
+    }
+
+    @Test
+    public void testRefreshTokenWhenCrossTenantRequestsAllowed() {
+      logger.info("POST signing request for a refresh token");
+
+      var response = given()
+        .header("X-Okapi-Tenant", tenant)
+        .header("X-Okapi-Token", accessToken)
+        .header("X-Okapi-Url", "http://localhost:" + freePort)
+        .header("Content-type", "application/json")
+        .header("X-Okapi-Permissions", "[\"" + getMagicPermission("/token/sign") + "\"]")
+        .body(new JsonObject().put("payload", payloadSigningRequest).encode())
+        .post("/token/sign")
+        .then()
+        .statusCode(201)
+        .contentType("application/json")
+        .body("$", hasKey(Token.ACCESS_TOKEN_EXPIRATION))
+        .body("$", hasKey(Token.REFRESH_TOKEN_EXPIRATION));
+
+      String rt = response.extract().path("refreshToken");
+      String at = response.extract().path("accessToken");
+
+      System.setProperty("allow.cross.tenant.requests", "true");
+      logger.info("POST refresh token to get a new refresh and access token with allow.cross.tenant.requests=true and member consortium tenant");
+
+      given()
+        .header("X-Okapi-Tenant", memberTenant)
+        .header("X-Okapi-Token", at)
+        .header("X-Okapi-Url", "http://localhost:" + freePort)
+        .header("Content-type", "application/json")
+        .header("X-Okapi-Permissions", "[\"" + getMagicPermission("/token/refresh") + "\"]")
+        .body(new JsonObject().put("refreshToken", rt).encode())
+        .post("/token/refresh")
+        .then()
+        .statusCode(201);
     }
 
     @Test

--- a/src/test/java/org/folio/auth/authtokenmodule/UsersMock.java
+++ b/src/test/java/org/folio/auth/authtokenmodule/UsersMock.java
@@ -56,20 +56,20 @@ public class UsersMock extends AbstractVerticle {
   }
 
   private void handleUserTenants(RoutingContext context) {
-    String userId = context.request().getHeader(XOkapiHeaders.TENANT);
+    String tenantId = context.request().getHeader(XOkapiHeaders.TENANT);
     // invalid response code for tenant 00
-    if (userId.contentEquals("00")) {
+    if (tenantId.contentEquals("00")) {
       context.response().setStatusCode(400).putHeader("Content-Type", "application/json").end();
       return;
     }
     // invalid response JSON for tenant 000
-    if (userId.contentEquals("000")) {
+    if (tenantId.contentEquals("000")) {
       context.response().setStatusCode(200).putHeader("Content-Type", "application/json")
         .end("invalid json");
       return;
     }
     // ok response code with valid json
-    if (userId.contentEquals("test-tenant-1")) {
+    if (tenantId.contentEquals("test-tenant-1")) {
       context.response().setStatusCode(200).putHeader("Content-Type", "application/json")
         .end(new JsonObject().put("totalRecords", 1).encode());
       return;


### PR DESCRIPTION
https://issues.folio.org/browse/MODAT-149

The 2 changes made here:

- Remove returning of failed future for refresh token when tenantId in headers do not match with tenantId in token. Instead common validation method used that allows cross tenant requests when all conditions met
- Refactor RefreshToken to use tenantId from token instead of headers to make it compatible with ECS when tenantId in header and token can be different, in this case need to use tenantId from token claims