### PR TITLE
MODAT-160: When a token isn't present in a request, return 400 rather than 403

### DIFF
--- a/src/main/java/org/folio/auth/authtokenmodule/apis/FilterApi.java
+++ b/src/main/java/org/folio/auth/authtokenmodule/apis/FilterApi.java
@@ -323,6 +323,8 @@ public class FilterApi extends Api implements RouterCreator {
               String msg;
               if (isDummyToken) {
                 msg = "Token missing, access requires permission: " + o;
+                endText(ctx, 400, msg);
+                return;
               } else {
                 msg = "Access for user '" + username + "' (" + finalUserId + ") requires permission: " + o;
               }

--- a/src/test/java/org/folio/auth/authtokenmodule/AuthTokenTest.java
+++ b/src/test/java/org/folio/auth/authtokenmodule/AuthTokenTest.java
@@ -299,7 +299,7 @@ public class AuthTokenTest {
         .header("X-Okapi-Permissions-Required", "[\"foo.req\"]")
         .get("/foo")
         .then()
-        .statusCode(403)
+        .statusCode(400)
         .body(containsString("Token missing"))
         .body(containsString("foo.req"))
         .header("X-Okapi-Module-Tokens", not(emptyString()));


### PR DESCRIPTION
https://issues.folio.org/browse/MODAT-160

This doesn't change all uses of the `403` response code, only the one which is causing trouble for the front end developers. `403` is still returned when the user id in `X-Okapi` and the token don't match. I think it is fine to still have other cases that return `403`. The key here is that we no longer use it for missing tokens.