### PR TITLE
MODAT-159: allow.cross.tenant.requests=false to disable consortia options

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -101,7 +101,7 @@
     },
     "env": [
       { "name": "JAVA_OPTIONS",
-        "value": "-XX:MaxRAMPercentage=66.0 -Dcache.permissions=true -Dallow.cross.tenant.requests=true"
+        "value": "-XX:MaxRAMPercentage=66.0 -Dcache.permissions=true"
       }
     ]
   }

--- a/src/test/java/org/folio/auth/authtokenmodule/TokenTest.java
+++ b/src/test/java/org/folio/auth/authtokenmodule/TokenTest.java
@@ -137,6 +137,15 @@ public class TokenTest {
     assertThat(t.getMessage(), is("Unable to parse token"));
   }
 
+  @Test
+  public void testAllowCrossTenantRequests() throws JOSEException, ParseException {
+    var contextWithoutSystemProperty = new TokenValidationContext(null, null, null, userService);
+    assertThat(contextWithoutSystemProperty.isAllowCrossTenantRequests(), is(false));
+    System.setProperty("allow.cross.tenant.requests", "true");
+    var contextWithSystemProperty = new TokenValidationContext(null, null, null, userService);
+    assertThat(contextWithSystemProperty.isAllowCrossTenantRequests(), is(true));
+  }
+
   private void assertTokenIsInvalid(String token, TokenCreator tokenCreator, int errorCode)  throws JOSEException, ParseException {
     MultiMap headers = Mockito.mock(MultiMap.class);
     Mockito.when(headers.get(XOkapiHeaders.USER_ID)).thenReturn(userUUID);


### PR DESCRIPTION
https://issues.folio.org/browse/MODAT-159